### PR TITLE
Handle stochastic triple-valued arrays

### DIFF
--- a/src/general_rules.jl
+++ b/src/general_rules.jl
@@ -171,6 +171,9 @@ function Base.getindex(C::AbstractArray, st::StochasticTriple{T}) where {T}
     function do_map(Δ)
         value(C[st.value + Δ]) - value(val)
     end
-    Δs = map(do_map, st.Δs)  # TODO: what if C itself contains stochastic duals with FIs?
+    Δs = map(do_map, st.Δs)
+    if val isa StochasticTriple
+        Δs = combine((Δs, val.Δs))
+    end
     return StochasticTriple{T}(value(val), delta(val), Δs)
 end

--- a/test/triples.jl
+++ b/test/triples.jl
@@ -108,3 +108,27 @@ end
     end
     @test stochastic_triple(1.0; backend = backend) != 1
 end end
+
+@testset "Array indexing" begin
+    p = 0.3
+    # Test indexing into array of floats with stochastic triple index
+    function array_index(p)
+        arr = [3.5, 5.2, 8.4]
+        index = rand(Categorical([p / 2, p / 2, 1 - p]))
+        return arr[index]
+    end
+    array_index_mean(p) = p / 2 * 3.5 + p / 2 * 5.2 + (1 - p) * 8.4
+    triple_array_index_deriv = mean(derivative_estimate(array_index, p) for i in 1:100000)
+    exact_array_index_deriv = ForwardDiff.derivative(array_index_mean, p)
+    @test isapprox(triple_array_index_deriv, exact_array_index_deriv, rtol = 5e-2)
+    # Test indexing into array of stochastic triples with stochastic triple index
+    function array_index2(p)
+        arr = [3.5 * rand(Bernoulli(p)), 5.2 * rand(Bernoulli(p)), 8.4 * rand(Bernoulli(p))]
+        index = rand(Categorical([p / 2, p / 2, 1 - p]))
+        return arr[index]
+    end
+    array_index2_mean(p) = p / 2 * 3.5p + p / 2 * 5.2p + (1 - p) * 8.4p
+    triple_array_index2_deriv = mean(derivative_estimate(array_index2, p) for i in 1:100000)
+    exact_array_index2_deriv = ForwardDiff.derivative(array_index2_mean, p)
+    @test isapprox(triple_array_index2_deriv, exact_array_index2_deriv, rtol = 5e-2)
+end


### PR DESCRIPTION
Patches up the `getindex` rule to correctly handle stochastic triple-valued arrays