### PR TITLE
Prevent chance of wrong floating point comparison in Categorical logic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticAD"
 uuid = "e4facb34-4f7e-4bec-b153-e122c37934ac"
 authors = ["Gaurav Arya <aryag@mit.edu> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/discrete_randomness.jl
+++ b/src/discrete_randomness.jl
@@ -137,7 +137,7 @@ end
 function δtoΔs(d::Categorical, val::V, δs, Δs::AbstractFIs) where {V <: Signed}
     p = params(d)[1]
     left_sum = sum(δs[1:(val - 1)], init = zero(V))
-    right_sum = left_sum + δs[val]
+    right_sum = -sum(δs[(val + 1):end], init = zero(V))
 
     if left_sum > 0
         stop = rand() * left_sum

--- a/test/triples.jl
+++ b/test/triples.jl
@@ -22,7 +22,8 @@ const backends = [
         Geometric,
         Poisson,
         (p -> Categorical([p^2, 1 - p^2])),
-        (p -> Categorical([0, p^2, 0, 0, 1 - p^2])), # To check that 0's are skipped over
+        (p -> Categorical([0, p^2, 0, 0, 1 - p^2])), # check that 0's are skipped over
+        (p -> Categorical([0.1, exp(p)] ./ (0.1 + exp(p)))), # test fix for #38 (floating point comparisons in Categorical logic)
         (p -> Binomial(3, p)),
         (p -> Binomial(20, p)),
     ]


### PR DESCRIPTION
Resolves #38: the issue was because of a comparison like `1e-17 < 0` holding true when we wanted it to be false (specifically in the comparison `right_sum < 0` in the logic for the Categorical variable). This fix sidesteps the issue by computing `right_sum` in a different way that shouldn't have this problem