### PR TITLE
Add stochastic triple smoothing backend

### DIFF
--- a/benchmark/game_of_life.jl
+++ b/benchmark/game_of_life.jl
@@ -16,6 +16,6 @@ suite["PrunedFIs"] = @benchmarkable derivative_estimate($play, $p;
 suite["PrunedFIsAggressive"] = @benchmarkable derivative_estimate($play, $p;
                                                                   backend = PrunedFIsAggressiveBackend())
 suite["SmoothedFIs"] = @benchmarkable derivative_estimate($play, $p;
-                                                                  backend = SmoothedFIsBackend())
+                                                          backend = SmoothedFIsBackend())
 
 end

--- a/benchmark/game_of_life.jl
+++ b/benchmark/game_of_life.jl
@@ -15,5 +15,7 @@ suite["PrunedFIs"] = @benchmarkable derivative_estimate($play, $p;
                                                         backend = PrunedFIsBackend())
 suite["PrunedFIsAggressive"] = @benchmarkable derivative_estimate($play, $p;
                                                                   backend = PrunedFIsAggressiveBackend())
+suite["SmoothedFIs"] = @benchmarkable derivative_estimate($play, $p;
+                                                                  backend = SmoothedFIsBackend())
 
 end

--- a/benchmark/random_walk.jl
+++ b/benchmark/random_walk.jl
@@ -16,6 +16,8 @@ suite["PrunedFIs"] = @benchmarkable derivative_estimate($fX, $p;
                                                         backend = PrunedFIsBackend())
 suite["PrunedFIsAggressive"] = @benchmarkable derivative_estimate($fX, $p;
                                                                   backend = PrunedFIsAggressiveBackend())
+suite["SmoothedFIs"] = @benchmarkable derivative_estimate($fX, $p;
+                                                                  backend = SmoothedFIsBackend())
 forwarddiff_func = p -> fX(p; hardcode_leftright_step = true)
 suite["ForwardDiff_smoothing"] = @benchmarkable derivative($forwarddiff_func, $p)
 

--- a/benchmark/random_walk.jl
+++ b/benchmark/random_walk.jl
@@ -17,7 +17,7 @@ suite["PrunedFIs"] = @benchmarkable derivative_estimate($fX, $p;
 suite["PrunedFIsAggressive"] = @benchmarkable derivative_estimate($fX, $p;
                                                                   backend = PrunedFIsAggressiveBackend())
 suite["SmoothedFIs"] = @benchmarkable derivative_estimate($fX, $p;
-                                                                  backend = SmoothedFIsBackend())
+                                                          backend = SmoothedFIsBackend())
 forwarddiff_func = p -> fX(p; hardcode_leftright_step = true)
 suite["ForwardDiff_smoothing"] = @benchmarkable derivative($forwarddiff_func, $p)
 

--- a/src/StochasticAD.jl
+++ b/src/StochasticAD.jl
@@ -5,7 +5,7 @@ module StochasticAD
 export stochastic_triple, derivative_contribution, perturbations # For working with stochastic triples
 export derivative_estimate, StochasticModel, stochastic_gradient # Higher level functionality
 export new_weight # Particle resampling
-export PrunedFIsBackend, PrunedFIsAggressiveBackend, DictFIsBackend
+export PrunedFIsBackend, PrunedFIsAggressiveBackend, DictFIsBackend, SmoothedFIsBackend
 
 ### Imports
 

--- a/src/backends/smoothed.jl
+++ b/src/backends/smoothed.jl
@@ -21,7 +21,7 @@ struct SmoothedFIs{V, V_float} <: StochasticAD.AbstractFIs{V}
     δ::V_float
     function SmoothedFIs{V}(δ) where {V}
         # hardcode Float64 representation for now, for simplicity.
-        δ_f64 = StochasticAD.structural_map(Float64, δ)
+        δ_f64 = StochasticAD.structural_map(Base.Fix1(convert, Float64), δ)
         return new{V, typeof(δ_f64)}(δ_f64)
     end
 end

--- a/src/backends/smoothed.jl
+++ b/src/backends/smoothed.jl
@@ -55,6 +55,7 @@ StochasticAD.create_Δs(::SmoothedFIsBackend, V) = SmoothedFIs{V}(0.0)
 function (::Type{<:SmoothedFIs{V}})(Δs::SmoothedFIs) where {V}
     SmoothedFIs{V}(Δs.δ)
 end
+(::Type{SmoothedFIs{V}})(Δs::SmoothedFIs) where {V} = SmoothedFIs{V}(Δs.δ)
 
 ### Getting information about perturbations
 

--- a/src/backends/smoothed.jl
+++ b/src/backends/smoothed.jl
@@ -2,36 +2,101 @@ module SmoothedFIsModule
 
 import ..StochasticAD
 
-export SmoothedFIs
+export SmoothedFIsBackend, SmoothedFIs
+
+"""
+    SmoothedFIsBackend <: StochasticAD.AbstractFIsBackend
+
+A backend algorithm that smooths perturbations togethers. 
+"""
+struct SmoothedFIsBackend <: StochasticAD.AbstractFIsBackend end
 
 """
     SmoothedFIs{V} <: StochasticAD.AbstractFIs{V}
 
-A backend that smooths perturbations together.
-The full backend interface is not supported, rather only the functions necessary for defining chain rules.
+The implementing backend structure for SmoothedFIsBackend.
 """
-struct SmoothedFIs{V, Vfloat} <: StochasticAD.AbstractFIs{V}
-    δ::Vfloat
+# TODO: make type of δ generic
+struct SmoothedFIs{V, V_float} <: StochasticAD.AbstractFIs{V}
+    δ::V_float
+    function SmoothedFIs{V}(δ) where {V}
+        # hardcode Float64 representation for now, for simplicity.
+        δ_f64 = StochasticAD.structural_map(Float64, δ)
+        return new{V, typeof(δ_f64)}(δ_f64)
+    end
 end
 
-SmoothedFIs{V}(δ::Vfloat) where {V, Vfloat} = SmoothedFIs{V, Vfloat}(δ)
+### Empty / no perturbation
 
-StochasticAD.similar_empty(::SmoothedFIs, V::Type) = SmoothedFIs{V}(zero(float(V)))
+StochasticAD.similar_empty(::SmoothedFIs, V::Type) = SmoothedFIs{V}(0.0)
+Base.empty(::Type{<:SmoothedFIs{V}}) where {V} = SmoothedFIs{V}(0.0)
+Base.empty(Δs::SmoothedFIs) = empty(typeof(Δs))
+
+### Create a new perturbation with infinitesimal probability
+
 function StochasticAD.similar_new(::SmoothedFIs, Δ::V, w::Real) where {V}
-    SmoothedFIs{V}(float(Δ) * w)
+    SmoothedFIs{V}(Δ * w)
+end
+
+StochasticAD.new_Δs_strategy(::SmoothedFIs) = StochasticAD.TwoSidedStrategy()
+
+### Scale a perturbation
+
+function StochasticAD.scale(Δs::SmoothedFIs{V}, scale::Real) where {V}
+    SmoothedFIs{V}(Δs.δ * scale)
+end
+
+### Create Δs backend for the first stochastic triple of computation
+
+StochasticAD.create_Δs(::SmoothedFIsBackend, V) = SmoothedFIs{V}(0.0)
+
+### Convert type of a backend
+
+function (::Type{<:SmoothedFIs{V}})(Δs::SmoothedFIs) where {V}
+    SmoothedFIs{V}(Δs.δ)
+end
+
+### Getting information about perturbations
+
+Base.isempty(Δs::SmoothedFIs) = false
+Base.iszero(Δs::SmoothedFIs) = iszero(Δs.δ)
+Base.iszero(Δs::SmoothedFIs{<:Tuple}) = all(iszero.(Δs.δ))
+StochasticAD.derivative_contribution(Δs::SmoothedFIs) = Δs.δ
+
+### Unary propagation
+
+function StochasticAD.map_Δs(f, Δs::SmoothedFIs; deriv, out_rep)
+    SmoothedFIs{typeof(out_rep)}(deriv(Δs.δ))
+end
+
+StochasticAD.alltrue(f, Δs::SmoothedFIs) = true
+
+### Coupling
+
+StochasticAD.get_rep(::Type{<:SmoothedFIs}, Δs_all) = first(Δs_all)
+
+function StochasticAD.couple(::Type{<:SmoothedFIs}, Δs_all; rep = nothing, out_rep)
+    SmoothedFIs{typeof(out_rep)}(StochasticAD.structural_map(Δs -> Δs.δ, Δs_all))
 end
 
 function StochasticAD.combine(::Type{<:SmoothedFIs}, Δs_all; rep = nothing)
+    V_out = StochasticAD.valtype(first(StochasticAD.structural_iterate(Δs_all)))
     Δ_combined = sum(Δs -> Δs.δ, StochasticAD.structural_iterate(Δs_all))
-    # TODO: using eltype below will not work in general, and the proper fix
-    # could be a caller-provided type. This is not yet needed for this function's
-    # limited internal use.
-    eltype(Δs_all)(Δ_combined)
+    SmoothedFIs{V_out}(Δ_combined)
 end
 
-StochasticAD.derivative_contribution(Δs::SmoothedFIs) = Δs.δ
+function StochasticAD.scalarize(Δs::SmoothedFIs; out_rep)
+    return StochasticAD.structural_map(out_rep, Δs.δ) do out, δ
+        return SmoothedFIs{typeof(out)}(δ)
+    end
+end
 
-function Base.show(io::IO, mime::MIME"text/plain", Δs::SmoothedFIs)
+### Miscellaneous
+
+StochasticAD.similar_type(::Type{<:SmoothedFIs}, V::Type) = SmoothedFIs{V}
+StochasticAD.valtype(::Type{<:SmoothedFIs{V}}) where {V} = V
+
+function Base.show(io::IO, Δs::SmoothedFIs)
     print(io, "$(Δs.δ)ε")
 end
 

--- a/src/finite_infinitesimals.jl
+++ b/src/finite_infinitesimals.jl
@@ -41,3 +41,8 @@ function map_Δs end
 function Base.map(f, Δs::AbstractFIs; kwargs...)
     StochasticAD.map_Δs((Δs, _) -> f(Δs), Δs; kwargs...)
 end
+
+function new_Δs_strategy end
+
+# Currently only supported / thought through for SmoothedFIs.
+function scale end

--- a/src/general_rules.jl
+++ b/src/general_rules.jl
@@ -265,7 +265,7 @@ function Base.getindex(C::AbstractArray, st::StochasticTriple{T, V, FIs}) where 
         return scale * δ
     end
 
-    Δs = StochasticAD.map_Δs(do_map, st.Δs; deriv, out_rep = val)
+    Δs = StochasticAD.map_Δs(do_map, st.Δs; deriv, out_rep = value(val))
     if val isa StochasticTriple
         Δs = combine((Δs, val.Δs))
     end

--- a/src/general_rules.jl
+++ b/src/general_rules.jl
@@ -240,6 +240,10 @@ function Base.isapprox(x::Real, st::StochasticTriple; kwargs...)
     return Base.isapprox(st, x; kwargs...)
 end
 
+
+# Alternate version of _isassigned that does not fall back on try/catch.
+_isassigned(C, i) = (i in eachindex(C))
+
 """
     Base.getindex(C::AbstractArray, st::StochasticTriple{T})
 
@@ -253,11 +257,11 @@ function Base.getindex(C::AbstractArray, st::StochasticTriple{T, V, FIs}) where 
 
     # TODO: below doesn't support sparse arrays, use something like nextind
     deriv = δ -> begin
-        scale = if isassigned(C, st.value + 1) && isassigned(C, st.value - 1)
+        scale = if _isassigned(C, st.value + 1) && _isassigned(C, st.value - 1)
             1 / 2 * (value(C[st.value + 1]) - value(C[st.value - 1]))
-        elseif isassigned(C, st.value + 1)
+        elseif _isassigned(C, st.value + 1)
             value(C[st.value + 1]) - value(C[st.value])
-        elseif isassigned(C, st.value - 1)
+        elseif _isassigned(C, st.value - 1)
             value(C[st.value]) - value(C[st.value - 1])
         else
             zero(eltype(C))

--- a/src/general_rules.jl
+++ b/src/general_rules.jl
@@ -240,7 +240,6 @@ function Base.isapprox(x::Real, st::StochasticTriple; kwargs...)
     return Base.isapprox(st, x; kwargs...)
 end
 
-
 # Alternate version of _isassigned that does not fall back on try/catch.
 _isassigned(C, i) = (i in eachindex(C))
 

--- a/src/general_rules.jl
+++ b/src/general_rules.jl
@@ -35,7 +35,7 @@ function define_triple_overload(sig)
         @eval function (f::$opT)(st::StochasticTriple)
             val = value(st)
             out = f(val)
-            if !alltrue(map(Δ -> (f(val + Δ) == out), st.Δs))
+            if !alltrue(Δ -> (f(val + Δ) == out), st.Δs)
                 error("Output of boolean predicate cannot depend on input (unsupported by StochasticAD)")
             end
             return out
@@ -60,7 +60,7 @@ function define_triple_overload(sig)
         @eval function (f::$opT)(st::StochasticTriple, x::Real)
             val = value(st)
             out = f(val, x)
-            if !alltrue(map(Δ -> (f(val + Δ, x) == out), st.Δs))
+            if !alltrue(Δ -> (f(val + Δ, x) == out), st.Δs)
                 error("Output of boolean predicate cannot depend on input (unsupported by StochasticAD)")
             end
             return $return_value_real
@@ -68,7 +68,7 @@ function define_triple_overload(sig)
         @eval function (f::$opT)(x::Real, st::StochasticTriple)
             val = value(st)
             out = f(x, val)
-            if !alltrue(map(Δ -> (f(x, val + Δ) == out), st.Δs))
+            if !alltrue(Δ -> (f(x, val + Δ) == out), st.Δs)
                 error("Output of boolean predicate cannot depend on input (unsupported by StochasticAD)")
             end
             return $return_value_real
@@ -78,9 +78,8 @@ function define_triple_overload(sig)
             val2 = value(st2)
             out = f(val1, val2)
 
-            Δs_coupled = couple((st1.Δs, st2.Δs))
-            safe_perturb = alltrue(map(Δs -> f(val1 + Δs[1], val2 + Δs[2]) == out,
-                                       Δs_coupled))
+            Δs_coupled = couple((st1.Δs, st2.Δs); out_rep = (val1, val2))
+            safe_perturb = alltrue(Δs -> f(val1 + Δs[1], val2 + Δs[2]) == out, Δs_coupled)
             if !safe_perturb
                 error("Output of boolean predicate cannot depend on input (unsupported by StochasticAD)")
             end
@@ -92,11 +91,15 @@ function define_triple_overload(sig)
             return
         end
         @eval function (f::$opT)(st::StochasticTriple{T}; kwargs...) where {T}
-            args_tangent = (NoTangent(), delta(st))
-            val, δ0 = frule(args_tangent, f, value(st); kwargs...)
+            run_frule = δ -> begin
+                args_tangent = (NoTangent(), δ)
+                return frule(args_tangent, f, value(st); kwargs...)
+            end
+            val, δ0 = run_frule(delta(st))
             δ = (δ0 isa ZeroTangent || δ0 isa NoTangent) ? zero(value(st)) : δ0
             if !iszero(st.Δs)
-                Δs = map(Δ -> f(st.value + Δ; kwargs...) - val, st.Δs)
+                Δs = map(Δ -> f(st.value + Δ; kwargs...) - val, st.Δs;
+                         deriv = last ∘ run_frule, out_rep = val)
             else
                 Δs = similar_empty(st.Δs, typeof(val))
             end
@@ -109,22 +112,30 @@ function define_triple_overload(sig)
         end
         for R in AMBIGUOUS_TYPES
             @eval function (f::$opT)(st::StochasticTriple{T}, x::$R; kwargs...) where {T}
-                args_tangent = (NoTangent(), delta(st), zero(x))
-                val, δ0 = frule(args_tangent, f, value(st), x; kwargs...)
+                run_frule = δ -> begin
+                    args_tangent = (NoTangent(), δ, zero(x))
+                    return frule(args_tangent, f, value(st), x; kwargs...)
+                end
+                val, δ0 = run_frule(delta(st))
                 δ = (δ0 isa ZeroTangent || δ0 isa NoTangent) ? zero(value(st)) : δ0
                 if !iszero(st.Δs)
-                    Δs = map(Δ -> f(st.value + Δ, x; kwargs...) - val, st.Δs)
+                    Δs = map(Δ -> f(st.value + Δ, x; kwargs...) - val, st.Δs;
+                             deriv = last ∘ run_frule, out_rep = val)
                 else
                     Δs = similar_empty(st.Δs, typeof(val))
                 end
                 return StochasticTriple{T}(val, δ, Δs)
             end
             @eval function (f::$opT)(x::$R, st::StochasticTriple{T}; kwargs...) where {T}
-                args_tangent = (NoTangent(), zero(x), delta(st))
-                val, δ0 = frule(args_tangent, f, x, value(st); kwargs...)
+                run_frule = δ -> begin
+                    args_tangent = (NoTangent(), zero(x), δ)
+                    return frule(args_tangent, f, x, value(st); kwargs...)
+                end
+                val, δ0 = run_frule(delta(st))
                 δ = (δ0 isa ZeroTangent || δ0 isa NoTangent) ? zero(value(st)) : δ0
                 if !iszero(st.Δs)
-                    Δs = map(Δ -> f(x, st.value + Δ; kwargs...) - val, st.Δs)
+                    Δs = map(Δ -> f(x, st.value + Δ; kwargs...) - val, st.Δs;
+                             deriv = last ∘ run_frule, out_rep = val)
                 else
                     Δs = similar_empty(st.Δs, typeof(val))
                 end
@@ -132,21 +143,24 @@ function define_triple_overload(sig)
             end
         end
         @eval function (f::$opT)(sts::Vararg{StochasticTriple{T}, 2}; kwargs...) where {T}
-            args_tangent = (NoTangent(), delta.(sts)...)
-            args = (f, value.(sts)...)
-            val, δ0 = frule(args_tangent, args...; kwargs...)
+            run_frule = δs -> begin
+                args_tangent = (NoTangent(), δs...)
+                args = (f, value.(sts)...)
+                return frule(args_tangent, args...; kwargs...)
+            end
+            val, δ0 = run_frule(delta.(sts))
             δ = (δ0 isa ZeroTangent || δ0 isa NoTangent) ? zero(value(st)) : δ0
 
             Δs_all = map(st -> getfield(st, :Δs), sts)
             if all(iszero.(Δs_all))
                 Δs = similar_empty(first(sts).Δs, typeof(val))
             else
-                Δs_coupled = couple(Tuple(Δs_all))
                 vals_in = value.(sts)
+                Δs_coupled = couple(Tuple(Δs_all); out_rep = vals_in)
                 mapfunc = let vals_in = vals_in
                     Δ -> (f((vals_in .+ Δ)...; kwargs...) - val)
                 end
-                Δs = map(mapfunc, Δs_coupled)
+                Δs = map(mapfunc, Δs_coupled; deriv = last ∘ run_frule, out_rep = val)
             end
             return StochasticTriple{T}(val, δ, Δs)
         end
@@ -235,10 +249,23 @@ A simple prototype rule for array indexing. Assumes that underlying type of `st`
 # Example to fix: A[:, :, st]
 function Base.getindex(C::AbstractArray, st::StochasticTriple{T, V, FIs}) where {T, V, FIs}
     val = C[st.value]
-    function do_map(Δ, state)
-        return value(C[st.value + Δ], state) - value(val, state)
+    do_map = (Δ, state) -> begin return value(C[st.value + Δ], state) - value(val, state) end
+
+    # TODO: below doesn't support sparse arrays, use something like nextind
+    deriv = δ -> begin
+        scale = if isassigned(C, st.value + 1) && isassigned(C, st.value - 1)
+            1 / 2 * (value(C[st.value + 1]) - value(C[st.value - 1]))
+        elseif isassigned(C, st.value + 1)
+            value(C[st.value + 1]) - value(C[st.value])
+        elseif isassigned(C, st.value - 1)
+            value(C[st.value]) - value(C[st.value - 1])
+        else
+            zero(eltype(C))
+        end
+        return scale * δ
     end
-    Δs = StochasticAD.map_Δs(do_map, st.Δs)
+
+    Δs = StochasticAD.map_Δs(do_map, st.Δs; deriv, out_rep = val)
     if val isa StochasticTriple
         Δs = combine((Δs, val.Δs))
     end

--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -81,7 +81,7 @@ function propagate(f, args...; keep_deltas = Val{false})
     Δs_all = structural_map(Base.Fix2(get_Δs, backendtype(st_rep)), args;
                             only_vals = Val{true}())
     # TODO: Coupling approach below needs to handle non-perturbable objects.
-    Δs_coupled = couple(backendtype(st_rep), Δs_all; rep = Δs_rep)
+    Δs_coupled = couple(backendtype(st_rep), Δs_all; rep = Δs_rep, out_rep = val)
 
     function map_func(Δ_coupled)
         perturbed_args = structural_map(+, primal_args, Δ_coupled)
@@ -94,7 +94,7 @@ function propagate(f, args...; keep_deltas = Val{false})
     end
     Δs = map(map_func, Δs_coupled)
     # TODO: make sure all FI backends support interface needed below
-    new_out = structural_map(out, scalarize(Δs)) do leaf_out, leaf_Δs
+    new_out = structural_map(out, scalarize(Δs; out_rep = val)) do leaf_out, leaf_Δs
         StochasticAD.StochasticTriple{tag(st_rep)}(value(leaf_out), delta(leaf_out),
                                                    leaf_Δs)
     end

--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -92,7 +92,7 @@ function propagate(f, args...; keep_deltas = Val{false})
         alt = f(perturbed_args...)
         return structural_map((x, y) -> value(x) - y, alt, val)
     end
-    Δs = map(map_func, Δs_coupled)
+    Δs = map(map_func, Δs_coupled; out_rep = val) # TODO: support deriv here, maybe via ForwardDiff?
     # TODO: make sure all FI backends support interface needed below
     new_out = structural_map(out, scalarize(Δs; out_rep = val)) do leaf_out, leaf_Δs
         StochasticAD.StochasticTriple{tag(st_rep)}(value(leaf_out), delta(leaf_out),

--- a/src/smoothing.jl
+++ b/src/smoothing.jl
@@ -32,9 +32,7 @@ end
 
 function smoothed_delta(d, val, δ)
     Δs_empty = SmoothedFIs{typeof(val)}(0.0)
-    partial_right = derivative_contribution(δtoΔs(d, val, δ, Δs_empty))
-    partial_left = -derivative_contribution(δtoΔs(d, val, -δ, Δs_empty))
-    return (partial_left + partial_right) / 2
+    return derivative_contribution(δtoΔs(d, val, δ, Δs_empty))
 end
 
 for (dist, i, field) in [

--- a/test/triples.jl
+++ b/test/triples.jl
@@ -148,7 +148,7 @@ end end
     end
     array_index2_mean(p) = sum([p / 2 * p, p / 2 * p, (1 - p) * p] .* arr)
     triple_array_index2_deriv = mean(derivative_estimate(array_index2, p; backend)
-                                     for i in 1:50000) 
+                                     for i in 1:50000)
     exact_array_index2_deriv = ForwardDiff.derivative(array_index2_mean, p)
     @test isapprox(triple_array_index2_deriv, exact_array_index2_deriv, rtol = 5e-2)
     # Test case where triple and alternate array value are coupled


### PR DESCRIPTION
TODO:

- finish updating tests (~including array indexing~, propagate interface, ~filter state~)
- ~add to benchmarks~
- ~type stability~
- `similar_type` does not give concrete type (needs #83)