### PR TITLE
Make propagate more like a monadic bind by supporting stochastic triple creating functions

### DIFF
--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -46,10 +46,12 @@ end
 
 Propagates `args` through a function `f`, handling stochastic triples by independently running `f` on the primal
 and the alternatives, rather than by inspecting the internals of `f` (which may possibly be unsupported by `StochasticAD`).
-Currently handles deterministic functions `f` with any input and output that is `fmap`-able by `Functors.jl`.
+Handles functions `f` with any input and output that is `fmap`-able by `Functors.jl`, including functions `f` that are closures
+over stochastic triples.
 If `f` has a continuously differentiable component, provide `keep_deltas = Val(true)`.
-If `f` may itself return stochastic triples even once perturbations have been stripped from `args`, 
-(e.g. because `f` closes over stochastic triples), then provide `keep_triples = Val(true)`.
+If continuous perturbations to `args` can cause discrete pertubations to be created within `f`, 
+then provide `keep_triples = Val(true)`.
+
 
 This functionality is orthogonal to dispatch: the idea is for this function to be the "backend" for operator 
 overloading rules based on dispatch. For example:

--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -123,14 +123,14 @@ function propagate(f,
     primal_args = structural_map(get_value, args)
     input_args = if keep_triples isa Val{true}
         structural_map(x -> strip_Δs(x; use_dual = Val(false)), args)
-    elseif keep_deltas isa Val{true} 
+    elseif keep_deltas isa Val{true}
         structural_map(strip_Δs, args)
     else
         primal_args
     end
     out = f(input_args...)
     val = structural_map(value, out)
-    Δs1 = structural_map(Base.Fix2(get_Δs, backendtype(st_rep)), out) 
+    Δs1 = structural_map(Base.Fix2(get_Δs, backendtype(st_rep)), out)
     # TODO: what does the only_vals do in the below and why?
     Δs_all = structural_map(Base.Fix2(get_Δs, backendtype(st_rep)), args;
         only_vals = Val{true}())
@@ -149,11 +149,11 @@ function propagate(f,
     Δs2 = map(map_func, Δs_coupled; out_rep = val, deriv)
 
     # TODO: make sure all FI backends support interface needed below
-    new_out = structural_map(out, Δs1, scalarize(Δs2; out_rep = val)) do leaf_out, leaf_Δs1, leaf_Δs2
+    new_out = structural_map(
+        out, Δs1, scalarize(Δs2; out_rep = val)) do leaf_out, leaf_Δs1, leaf_Δs2
         leaf_Δs = combine(backendtype(st_rep), (leaf_Δs1, leaf_Δs2))
         StochasticAD.StochasticTriple{tag(st_rep)}(value(leaf_out), delta(leaf_out),
             leaf_Δs)
     end
     return new_out
 end
-


### PR DESCRIPTION
x-ref #128. @GuusAvis example:

```julia
using StochasticAD
using Distributions

function f(value_1, value_2, rand_var)
    if value_1 < value_2
        return (value_1 + rand(rand_var), value_2)
    else
        return (value_1, value_2 + rand(rand_var))
    end
end

propagate_f(value_1, value_2, rand_var) = StochasticAD.propagate((v1, v2) -> f(v1, v2, rand_var), value_1, value_2)

f(value_1::StochasticTriple, value_2, rand_var) = propagate_f(value_1, value_2, rand_var)
f(value_1, value_2::StochasticTriple, rand_var) = propagate_f(value_1, value_2, rand_var)
f(value_1::StochasticTriple, value_2::StochasticTriple, rand_var) = propagate_f(value_1, value_2, rand_var)

function g(p)
    rand_var = Bernoulli(p)
    value_1 = 0
    value_2 = 2
    for i in 1:10
        value_1, value_2 = f(value_1, value_2, rand_var)
    end
    return value_1, value_2
end

@show g(0.5)
@show mean((sum(g(0.6)) - sum(g(0.5))) / 0.1 for i in 1:1000) # 9.59
@show mean(derivative_estimate(p -> sum(g(p)), 0.5) for i in 1:100) # 8.84
```

@GuusAvis let me know if you have any issues, and if things work out adding the above as a test to `triples.jl` would be most welcome:) 