### PR TITLE
Type checking for propagate kwargs.

### DIFF
--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -92,8 +92,8 @@ StochasticTriple of Int64:
 """
 function propagate(f,
         args...;
-        keep_deltas = Val(false),
-        keep_triples = Val(false),
+        keep_deltas::Val = Val(false),
+        keep_triples::Val = Val(false),
         provided_st_rep = nothing,
         deriv = nothing)
     # TODO: support kwargs to f (or just use kwfunc in macro)

--- a/test/triples.jl
+++ b/test/triples.jl
@@ -529,7 +529,7 @@ end
                 out_δ_expected = StochasticAD.structural_map(zero, out)
             end
             input_sts = StochasticAD.structural_map(_form_triple, primals, δs, Δs)
-            out_st = StochasticAD.propagate(f, input_sts...; keep_deltas = Val{test_deltas})
+            out_st = StochasticAD.propagate(f, input_sts...; keep_deltas = Val(test_deltas))
             # Test type
             StochasticAD.structural_map(out_st, out, out_δ_expected,
                 out_Δ_expected) do x_st, x, δ, Δ


### PR DESCRIPTION
Added type testing for some kwargs in `propagate`, and adjusted a test that I think was already failing because of a wrong type but now it no longer fails quietly.

This is basically the same as https://github.com/gaurav-arya/StochasticAD.jl/pull/126, but applied to the changes of #132 (where an extra kwarg was introduced) and with a fix of the test.

Unfortunately is seems that the changes are triggering the failing of some other tests. I think the problem is that now, in case `keep_deltas isa Val{true}` but `keep_triples isa Val{false}`, `propagate` sometimes returns a `Dual` type instead of a `StochasticTriple` type. The test expects the latter though. I'm not entirely sure what the intended behavior is though so I won't make any further changes without further discussion.