### PR TITLE
Add tests for propagate

### DIFF
--- a/test/triples.jl
+++ b/test/triples.jl
@@ -658,14 +658,14 @@ end
 
         f9(value_1::StochasticTriple, value_2, rand_var) = propagate_f9(value_1, value_2, rand_var)
         f9(value_1, value_2::StochasticTriple, rand_var) = propagate_f9(value_1, value_2, rand_var)
-        f9(value_1::StochasticTriple, value_2::StochasticTriple, rand_var) = propagate_f9(value_1, value_2, rand_var 
+        f9(value_1::StochasticTriple, value_2::StochasticTriple, rand_var) = propagate_f9(value_1, value_2, rand_var)
 
         function g(p)
             rand_var = Bernoulli(p)
             value_1 = 0
             value_2 = 2
             for _ in 1:10
-                value_1, value_2 = f(value_1, value_2, rand_var)
+                value_1, value_2 = f9(value_1, value_2, rand_var)
             end
             return value_1, value_2
         end


### PR DESCRIPTION
Added two new tests of propagate that check if finite perturbations returned by functions upon normal calls are treated correctly by `propagate`.
1. Adding two stochastic triples together, like in https://github.com/gaurav-arya/StochasticAD.jl/issues/128#issue-2354290214; the way I'm constructing the stochastic triples may be nonstandard/bad practice though.
2. Step-game-like example that @gaurav-arya provided in https://github.com/gaurav-arya/StochasticAD.jl/pull/132. It's a statistical test so it can fail, but I set some pretty wide margins (basically 10 sigma) so it should be quite rare I think. Let me know if this is what you had in mind.

I'm open to suggestions!

I expect the tests for this PR to fail because there are still the issues in #133 , probably that should be dealt with first before looking more closely at this one.