### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/backends/pruned.jl
+++ b/src/backends/pruned.jl
@@ -43,8 +43,7 @@ mutable struct PrunedFIsState{M, W}
 end
 
 Base.:(==)(state1::PrunedFIsState, state2::PrunedFIsState) = state1.tag == state2.tag
-# c.f. https://github.com/JuliaLang/julia/blob/61c3521613767b2af21dfa5cc5a7b8195c5bdcaf/base/hashing.jl#L38C45-L38C51
-Base.hash(state::PrunedFIsState) = state.tag
+Base.hash(state::PrunedFIsState, h::UInt) = hash(state.tag, h)
 
 """
     PrunedFIs{V} <: StochasticAD.AbstractFIs{V}


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.